### PR TITLE
Switch from SweetAlert to SweetAlert2

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "path-to-regexp": "^1.7.0",
     "simplemde": "^1.11.2",
     "social-share.js": "^1.0.15",
-    "sweetalert": "^1.1.3",
+    "sweetalert2": "^7.0.9",
     "toastr": "^2.1.2",
     "v-textcomplete": "^0.1.2",
     "vue": "^2.1.6",

--- a/resources/assets/js/bootstrap.js
+++ b/resources/assets/js/bootstrap.js
@@ -9,7 +9,7 @@ window._ = require('lodash');
 
 window.$ = window.jQuery = require('jquery');
 require('bootstrap-sass');
-window.swal = require('sweetalert');
+window.swal = require('sweetalert2');
 
 /**
  * Vue is a modern JavaScript library for building interactive web interfaces

--- a/resources/assets/js/components/dashboard/CustomAction.vue
+++ b/resources/assets/js/components/dashboard/CustomAction.vue
@@ -29,12 +29,10 @@ export default{
                 text: "The action may affect some data, Please think twice!",
                 type: "warning",
                 showCancelButton: true,
-                closeOnConfirm: true,
                 confirmButtonColor: "#DD6B55",
                 confirmButtonText: "Yes, changed it!",
-            },
-            function () {
-                index.postData(rowData)
+            }).then(function (result) {
+                result.value && index.postData(rowData)
             })
         },
         postData(rowData) {

--- a/resources/assets/js/config/helper.js
+++ b/resources/assets/js/config/helper.js
@@ -14,8 +14,7 @@ export function stack_error(response) {
         swal({
             title: "Error Text!",
             type: 'error',
-            text: content,
-            html: true
+            html: content
         });
     }
 }


### PR DESCRIPTION
I would like to propose to switch from SweetAlert to [SweetAlert2](https://github.com/limonte/sweetalert2) - the supported fork of SweetAlert. The original reason for creating SweetAlert2 is the inactivity of SweetAlert: https://stackoverflow.com/a/27842854/1331425 

### Reasons to switch:

1. Accessibility (WAI-ARIA) - SweetAlert2 is fully WAI-ARIA compatible and supports all popular screen-readers. Accessibility is a must in 2017, there are a lot of explanatory and tech articles, but this one is truly inspirable: [Software development 450 words per minute](https://www.vincit.fi/en/blog/software-development-450-words-per-minute/)

2. Better buttons contrast is a huge advantage for all users especially for users with vision disabilities. 

3. Better support, average time to resolve an issue:

   - SweetAlert: ![](http://isitmaintained.com/badge/resolution/t4t5/sweetalert.svg)
   - SweetAlert2: ![](http://isitmaintained.com/badge/resolution/limonte/sweetalert2.svg)

4. SweetAlert2 is more popular that SweetAlert:

   - SweetAlert: ![](https://img.shields.io/npm/dm/sweetalert.svg)
   - SweetAlert2: ![](https://img.shields.io/npm/dm/sweetalert2.svg)
