### PR TITLE
fix word spell

### DIFF
--- a/app/Console/Commands/BlogInstall.php
+++ b/app/Console/Commands/BlogInstall.php
@@ -42,7 +42,7 @@ class BlogInstall extends Command
     }
 
     /**
-     * Exec sheel with pretty print.
+     * Exec shell with pretty print.
      *
      * @param  string $command
      * @return mixed


### PR DESCRIPTION
`app/Console/Commands/BlogInstall.php` 中注释单词拼写问题。 `sheel` => `shell`