### PR TITLE
added policy for commenting on an article. check auth and is_draft

### DIFF
--- a/app/Http/Controllers/Api/CommentController.php
+++ b/app/Http/Controllers/Api/CommentController.php
@@ -39,9 +39,14 @@ class CommentController extends ApiController
      */
     public function store(CommentRequest $request)
     {
-        $data = array_merge($request->all(), [
-            'user_id' => Auth::user()->id,
-        ]);
+
+		$data = $request->all();
+		if ($data['commentable_type'] === 'articles') {
+			$article = \App\Article::find($data['commentable_id']);
+			if (!auth()->user()->can('comment',$article)) return response()->json([],403);
+		}
+
+        $data['user_id'] = Auth::user()->id;
 
         $mention = new Mention();
         $data['content'] = $mention->parse($data['content']);

--- a/app/Policies/ArticlePolicy.php
+++ b/app/Policies/ArticlePolicy.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Policies;
+
+use App\User;
+use App\Article;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class ArticlePolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can comment to this article.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Article  $article
+     * @return bool
+     */
+	public function comment(User $user, Article $article) {
+		return auth()->check() && !$article->is_draft;
+	}
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -16,6 +16,7 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected $policies = [
         \App\User::class => \App\Policies\UserPolicy::class,
+        \App\Article::class => \App\Policies\ArticlePolicy::class,
         \App\Comment::class => \App\Policies\CommentPolicy::class,
         \App\Discussion::class => \App\Policies\DiscussionPolicy::class,
     ];

--- a/resources/views/article/show.blade.php
+++ b/resources/views/article/show.blade.php
@@ -46,18 +46,15 @@
         </div>
     </div>
 
-    @if(Auth::guest())
-        <comment title="评论"
-                 commentable-type="articles"
-                 commentable-id="{{ $article->id }}"></comment>
-    @else
-        <comment title="评论"
-                 username="{{ Auth::user()->name }}"
-                 user-avatar="{{ Auth::user()->avatar }}"
-                 commentable-type="articles"
-                 commentable-id="{{ $article->id }}"
-                 can-comment></comment>
-    @endif
+	<comment title="Comments"
+	commentable-type="articles"
+	commentable-id="{{ $article->id }}"
+	@can('comment',$article)
+	username="{{ Auth::user()->name }}"
+	user-avatar="{{ Auth::user()->avatar }}"
+	can-comment
+	@endcan
+	></comment>
 
 @endsection
 


### PR DESCRIPTION
I added a new policy for checking if the signed in user can comment on an article. This policy checks that the user is logged in and the draft has been publiched, meaning that the "is_draft" property is false.

This solution is meant to fix error [#163 ](https://github.com/jcc/blog/issues/163)